### PR TITLE
Update usage to go-rested Send method

### DIFF
--- a/cveget.go
+++ b/cveget.go
@@ -4,9 +4,10 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"github.com/scottdware/go-rested"
 	"os"
 	"strings"
+
+	"github.com/scottdware/go-rested"
 )
 
 type CVE struct {
@@ -48,13 +49,14 @@ func init() {
 }
 
 func main() {
-	feedData := rested.Send(rssNormal, nil)
+	req := rested.NewRequest()
+	feedData := req.Send("get", rssNormal, nil, nil, nil)
 	if feedData.Error != nil {
 		fmt.Println(feedData.Error)
 	}
 
 	if a {
-		feedData = rested.Send(rssAnalyzed, nil)
+		feedData = req.Send("get", rssAnalyzed, nil, nil, nil)
 		if feedData.Error != nil {
 			fmt.Println(feedData.Error)
 		}


### PR DESCRIPTION
An update to the [go-rested](https://github.com/scottdware/go-rested) package, in particular the (*Request).Send() function, prevented `cveget` from being able to build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scottdware/cveget/1)
<!-- Reviewable:end -->
